### PR TITLE
Enable DBs separately

### DIFF
--- a/charts/meta-monitoring/Chart.yaml
+++ b/charts/meta-monitoring/Chart.yaml
@@ -27,19 +27,22 @@ dependencies:
 - name: loki
   repository:  https://grafana.github.io/helm-charts
   version: "5.8.0"
-  condition: local.enabled
+  condition: local.logs.enabled
 - name: grafana-agent
   repository:  https://grafana.github.io/helm-charts
   version: "0.15.0"
 - name: mimir-distributed
   repository:  https://grafana.github.io/helm-charts
   version: "4.4.1"
-  condition: local.enabled
+  condition: local.metrics.enabled
 - name: tempo-distributed
   repository:  https://grafana.github.io/helm-charts
   version: "1.4.7"
-  condition: local.enabled
+  condition: local.traces.enabled
 - name: minio
   repository: https://charts.min.io
   version: "5.0.11"
-  condition: local.enabled
+  tags:
+  - local-logs
+  - local-metrics
+  - local-traces

--- a/charts/meta-monitoring/templates/agent/_helpers-agent.tpl
+++ b/charts/meta-monitoring/templates/agent/_helpers-agent.tpl
@@ -8,10 +8,10 @@
 
 {{- define "agent.loki_write_targets" -}}
 {{- $list := list }}
-{{- if .Values.local.enabled }}
+{{- if .Values.local.logs.enabled }}
 {{- $list = append $list ("loki.write.local.receiver") }}
 {{- end }}
-{{- if .Values.cloud.enabled }}
+{{- if .Values.cloud.logs.enabled }}
 {{- $list = append $list ("loki.write.cloud.receiver") }}
 {{- end }}
 {{- join ", " $list }}
@@ -19,10 +19,10 @@
 
 {{- define "agent.prometheus_write_targets" -}}
 {{- $list := list }}
-{{- if .Values.local.enabled }}
+{{- if .Values.local.metrics.enabled }}
 {{- $list = append $list ("prometheus.remote_write.local.receiver") }}
 {{- end }}
-{{- if .Values.cloud.enabled }}
+{{- if .Values.cloud.metrics.enabled }}
 {{- $list = append $list ("prometheus.remote_write.cloud.receiver") }}
 {{- end }}
 {{- join ", " $list }}
@@ -30,10 +30,10 @@
 
 {{- define "agent.tempo_write_targets" -}}
 {{- $list := list }}
-{{- if .Values.local.enabled }}
+{{- if .Values.local.traces.enabled }}
 {{- $list = append $list ("otelcol.exporter.otlp.local.input") }}
 {{- end }}
-{{- if .Values.cloud.enabled }}
+{{- if .Values.cloud.traces.enabled }}
 {{- $list = append $list ("otelcol.exporter.otlp.cloud.input") }}
 {{- end }}
 {{- join ", " $list }}

--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -37,16 +37,21 @@ data:
       }
     }
 
+    {{- if or .Values.local.logs.enabled .Values.cloud.logs.enabled }}
     loki.source.kubernetes "pods" {
       targets    = discovery.relabel.rename_meta_labels.output
       forward_to = [ {{ include "agent.loki_write_targets" . }} ]
     }
+    {{- end }}
 
+    {{- if or .Values.local.metrics.enabled .Values.cloud.metrics.enabled }}
     prometheus.scrape "pods" {
       targets    = discovery.relabel.rename_meta_labels.output
       forward_to = [ {{ include "agent.prometheus_write_targets" . }} ]
     }
+    {{- end }}
 
+    {{- if or .Values.local.traces.enabled .Values.cloud.traces.enabled }}
     // Shamelessly copied from https://github.com/grafana/intro-to-mlt/blob/main/agent/config.river
     otelcol.receiver.otlp "otlp_receiver" {
       // We don't technically need this, but it shows how to change listen address and incoming port.
@@ -75,20 +80,25 @@ data:
             traces = [ {{ include "agent.tempo_write_targets" . }} ]
         }
     }
+    {{- end }}
 
-    {{- if .Values.local.enabled }}
+    {{- if .Values.local.logs.enabled }}
     loki.write "local" {
       endpoint {
         url = "http://loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local:80/loki/api/v1/push"
       }
     }
+    {{- end }}
 
+    {{- if .Values.local.metrics.enabled }}
     prometheus.remote_write "local" {
       endpoint {
         url = "http://{{- .Release.Name -}}-mimir-nginx.{{- .Release.Namespace -}}.svc:80/api/v1/push"
       }
     }
+    {{- end }}
 
+    {{- if or .Values.local.traces.enabled .Values.cloud.traces.enabled }}
     // The OpenTelemetry exporter exports processed trace spans to another target that is listening for OTLP format traces.
     // A unique label, 'local', is added to uniquely identify this exporter.
     otelcol.exporter.otlp "local" {
@@ -107,7 +117,7 @@ data:
     }
     {{- end }}
 
-    {{- if .Values.cloud.enabled }}
+    {{- if .Values.cloud.logs.enabled }}
     loki.write "cloud" {
       endpoint {
         url = "{{- .Values.cloud.logs.endpoint -}}/loki/api/v1/push"
@@ -118,7 +128,9 @@ data:
         }
       }
     }
+    {{- end }}
 
+    {{- if .Values.cloud.metrics.enabled }}
     prometheus.remote_write "cloud" {
       endpoint {
         url = "{{- .Values.cloud.metrics.endpoint -}}/api/prom/push"
@@ -129,7 +141,9 @@ data:
         }
       }
     }
+    {{- end }}
 
+    {{- if .Values.cloud.traces.enabled }}
     otelcol.exporter.otlp "cloud" {
         client {
             endpoint = "{{- .Values.cloud.traces.endpoint -}}"

--- a/charts/meta-monitoring/templates/grafana/configmap-1.yaml
+++ b/charts/meta-monitoring/templates/grafana/configmap-1.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.local.enabled }}
+{{- if .Values.local.logs.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/meta-monitoring/templates/grafana/configmap-2.yaml
+++ b/charts/meta-monitoring/templates/grafana/configmap-2.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.local.enabled }}
+{{- if .Values.local.logs.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/meta-monitoring/templates/grafana/dashboard.yaml
+++ b/charts/meta-monitoring/templates/grafana/dashboard.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.local.enabled }}
+{{- if .Values.local.logs.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/meta-monitoring/templates/grafana/datasources.yaml
+++ b/charts/meta-monitoring/templates/grafana/datasources.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.local.enabled }}
+{{- if or (or .Values.local.logs.enabled .Values.local.metrics.enabled) .Values.local.traces.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -20,6 +20,7 @@ data:
     datasources:
       # <string, required> Sets the name you use to refer to
       # the data source in panels and queries.
+      {{- if .Values.local.logs.enabled }}
       - name: Loki
         # <string, required> Sets the data source type.
         type: loki
@@ -39,6 +40,8 @@ data:
         # <bool> Allows users to edit data sources from the
         # Grafana UI.
         editable: true
+      {{- end }}
+      {{- if .Values.local.metrics.enabled }}
       - name: Mimir
         # <string, required> Sets the data source type.
         type: prometheus
@@ -58,6 +61,8 @@ data:
         # <bool> Allows users to edit data sources from the
         # Grafana UI.
         editable: true
+      {{- end }}
+      {{- if .Values.local.traces.enabled }}
       - name: Tempo
         # <string, required> Sets the data source type.
         type: tempo
@@ -77,4 +82,5 @@ data:
         # <bool> Allows users to edit data sources from the
         # Grafana UI.
         editable: true
+      {{- end }}
 {{- end }}

--- a/charts/meta-monitoring/templates/grafana/grafana.yaml
+++ b/charts/meta-monitoring/templates/grafana/grafana.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.local.enabled }}
+{{- if or (or .Values.local.logs.enabled .Values.local.metrics.enabled) .Values.local.traces.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -63,30 +63,34 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv
+            - mountPath: /etc/grafana/provisioning/datasources
+              name: loki-datasources-provisioning
+            {{- if .Values.local.logs.enabled }}
+            - mountPath: /etc/grafana/provisioning/dashboards
+              name: loki-dashboards-provisioning
             - mountPath: /var/lib/grafana/dashboards/loki-1
               name: loki-dashboards-1
             - mountPath: /var/lib/grafana/dashboards/loki-2
               name: loki-dashboards-2
-            - mountPath: /etc/grafana/provisioning/dashboards
-              name: loki-dashboards-provisioning
-            - mountPath: /etc/grafana/provisioning/datasources
-              name: loki-datasources-provisioning
+            {{- end }}
       volumes:
         - name: grafana-pv
           persistentVolumeClaim:
             claimName: grafana-pvc
-        - name: loki-dashboards-provisioning
-          configMap:
-            name: loki-dashboards-provisioning
         - name: loki-datasources-provisioning
           configMap:
             name: loki-datasources-provisioning
+        {{- if .Values.local.logs.enabled }}
+        - name: loki-dashboards-provisioning
+          configMap:
+            name: loki-dashboards-provisioning
         - name: loki-dashboards-1
           configMap:
             name: loki-dashboards-1
         - name: loki-dashboards-2
           configMap:
             name: loki-dashboards-2
+        {{- end }}
 
 ---
 apiVersion: v1

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -3,19 +3,35 @@ namespacesToMonitor:
 - mimir
 - tempo
 clusterName: "observability"  # TODO check if this can be derived
+
+# Turn on or off for local storing of metrics, logs or traces
+tags:
+  local-logs: true
+  local-metrics: true
+  local-traces: true
+
+# Unfortunately this is duplicate as Helm's tags and conditions fro dependencies are limited
 local:
-  enabled: true
-cloud:
-  enabled: false
   logs:
+    enabled: false
+  metrics:
+    enabled: false
+  traces:
+    enabled: false
+
+cloud:
+  logs:
+    enabled: true
     endpoint:
     username:
     password:
   metrics:
+    enabled: true
     endpoint:
     username:
     password:
   traces:
+    enabled: true
     endpoint:
     username:
     password:


### PR DESCRIPTION
Add settings to enable each DB separately. The Helm dependencies aren't installed if they are not needed. The Loki dashboards are not installed if a local Loki is not used. Only the relevant datasources are installed.
