### PR TITLE
Add regexes to filter log lines

### DIFF
--- a/charts/meta-monitoring/templates/agent/_helpers-agent.tpl
+++ b/charts/meta-monitoring/templates/agent/_helpers-agent.tpl
@@ -18,7 +18,7 @@
 {{- end }}
 
 {{- define "agent.loki_process_targets" -}}
-{{- if empty .Values.logs.piiregexes }}
+{{- if empty .Values.logs.piiRegexes }}
 {{- include "agent.loki_write_targets" . }}
 {{- else }}
 {{- printf "loki.process.PII.receiver" }}

--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -43,14 +43,15 @@ data:
       forward_to = [ {{ include "agent.loki_process_targets" . }} ]
     }
 
-    {{- if not (empty .Values.logs.piiregexes) }}
+    {{- if not (empty .Values.logs.piiRegexes) }}
     loki.process "PII" {
       forward_to = [ {{ include "agent.loki_write_targets" . }} ]
 
-      {{- range .Values.logs.piiregexes }}
+      {{- range .Values.logs.piiRegexes }}
       stage.replace {
-        expression = "{{ . }}"
-        replace = "*****"
+        expression = "{{ .expression }}"
+        source = "{{ .source }}"
+        replace = "{{ .replace }}"
       }
       {{- end }}
     }

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -32,14 +32,14 @@ cloud:
     username:
     password:
 
-# Adding regexes here will add a stage.replace block that parses the log lines using a regular expression
-# and replaces the capture group in the regex with "*****".
-# For example the regex "password (\\S+)" will replace the line
-#  we should not be logging the password xyzabc at all
-# with:
-#  we should not be logging the password ***** at all
+# Adding regexes here will add a stage.replace block. For more information see
+# https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagereplace-block
 logs:
-  piiregexes:
+  piiRegexes:
+  # This example replaces the word after password with *****
+  # - expression: "password (\\\\S+)"
+  #   source: ""         # Empty uses the log message
+  #   replace: "*****""
 
 global:
   minio:


### PR DESCRIPTION
Tested by setting the following regexes:
```
logs:
  piiRegexes:
  - expression: "password (\\\\S+)"
    replace: "****"
  - expression: "GET (\\\\S+)"
    source: ""
    replace: "****"
```

The log lines collected by Loki looked like this:

```
level=debug ts=2023-07-25T09:15:37.718485854Z caller=logging.go:101 traceID=6e62e36eb50eb051 msg="GET **** (200) 53.2µs"
192.168.169.182 - - [25/Jul/2023:09:15:30 +0000]  200 "GET **** HTTP/1.1" 2 "-" "kube-probe/1.25+" "-"
```
