### PR TITLE
Add scraping of kube state metrics

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -49,6 +49,13 @@ data:
       targets    = discovery.relabel.rename_meta_labels.output
       forward_to = [ {{ include "agent.prometheus_write_targets" . }} ]
     }
+    {{- if .Values.kubeStateMetrics.enabled }}
+
+    prometheus.scrape "kubeStateMetrics" {
+      targets    = [ { "__address__" = "{{ .Values.kubeStateMetrics.endpoint }}" } ]
+      forward_to = [ {{ include "agent.prometheus_write_targets" . }} ]
+    }
+    {{- end }}
     {{- end }}
 
     {{- if or .Values.local.traces.enabled .Values.cloud.traces.enabled }}

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -37,6 +37,14 @@ global:
     rootUser: "rootuser"
     rootPassword: "rootpassword"
 
+kubeStateMetrics:
+  # Scrape https://github.com/kubernetes/kube-state-metrics by default
+  enabled: true
+  # This endpoint is created when the helm chart from
+  # https://artifacthub.io/packages/helm/prometheus-community/kube-state-metrics/
+  # is used. Change this if kube-state-metrics is installed somewhere else.
+  endpoint: kube-state-metrics.kube-state-metrics.svc.cluster.local:8080
+
 # The following are configuration for the dependencies.
 # These should not be changed.
 


### PR DESCRIPTION
Add the option of scraping the kube state metrics. 
This is on by default. There is a setting to change the endpoint if it is installed somewhere else.

Tested by installing it and checking that the metrics are scraped.