### PR TITLE
Remove the scrape_interval settings

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -121,7 +121,6 @@ data:
       targets    = discovery.relabel.all_nodes.output
       forward_to = [ {{ include "agent.prometheus_write_targets" . }} ]
 
-      scrape_interval = "15s"
       metrics_path = "/metrics/cadvisor"
       scheme = "https"
 
@@ -135,7 +134,6 @@ data:
       targets    = discovery.relabel.all_nodes.output
       forward_to = [ {{ include "agent.prometheus_write_targets" . }} ]
 
-      scrape_interval = "15s"
       metrics_path = "/metrics"
       scheme = "https"
 
@@ -152,7 +150,6 @@ data:
       forward_to = [prometheus.relabel.node_exporter.receiver]
 
       job_name = "node-exporter"
-      scrape_interval = "15s"
     }
 
     prometheus.relabel "node_exporter" {


### PR DESCRIPTION
The default is 60s which matches the way GC datasources are configured for 60s or 1DPM for the provisioned prometheus instances. This will make sure $__auto and $__rate_interval are correct.