### PR TITLE
Also get logs and metrics for agents

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -8,7 +8,7 @@ data:
     discovery.kubernetes "pods" {
       role = "pod"
       namespaces {
-        own_namespace = false
+        own_namespace = true
         names = [ {{ include "agent.namespaces" . }} ]
       }
     }


### PR DESCRIPTION
The agent will now scrape metrics and gather logs for it's own pods. Tested in k3d while sending to the cloud. Logs and metrics for the agent pods are there now.