### PR TITLE
Fix logline filtering

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -32,8 +32,9 @@ data:
         target_label = "job"
       }
       rule {
-        target_label = "cluster"
-        replacement = "{{- .Values.clusterName -}}"
+        source_labels = ["__meta_kubernetes_pod_container_port_name"]
+        regex="(?!http-metrics)"
+        action = "drop"
       }
     }
 

--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -31,11 +31,11 @@ data:
         replacement = "${1}/${2}-${3}"
         target_label = "job"
       }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_name"]
-        regex="(?!http-metrics)"
-        action = "drop"
-      }
+      // rule {
+      //   source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      //   regex="http-metrics"
+      //   action = "keep"
+      // }
     }
 
     // Logs

--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -31,11 +31,10 @@ data:
         replacement = "${1}/${2}-${3}"
         target_label = "job"
       }
-      // rule {
-      //   source_labels = ["__meta_kubernetes_pod_container_port_name"]
-      //   regex="http-metrics"
-      //   action = "keep"
-      // }
+      rule {
+        target_label = "cluster"
+        replacement = "{{- .Values.clusterName -}}"
+      }
     }
 
     // Logs
@@ -55,7 +54,7 @@ data:
 
       {{- if not (empty .Values.logs.retain) }}
       stage.match {
-        selector = "{cluster=\"{{- .Values.clusterName -}}\"} !~ \"{{ join "|" .Values.logs.retain }}\""
+        selector = "{cluster=\"{{- .Values.clusterName -}}\", namespace=\"{{- .Values.lokiNamespace -}}\"} !~ \"{{ join "|" .Values.logs.retain }}\""
         action   = "drop"
       }
       {{- end }}

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -6,7 +6,6 @@ namespacesToMonitor:
 # The name of the cluster where this will be installed
 clusterName: "meta-monitoring"
 lokiNamespace: "loki"
-httpPort: 3100
 
 # Set to true to write logs, metrics or traces to Grafana Cloud
 cloud:

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -5,6 +5,7 @@ namespacesToMonitor:
 - tempo
 # The name of the cluster where this will be installed
 clusterName: "meta-monitoring"
+lokiNamespace: "loki"
 httpPort: 3100
 
 # Set to true to write logs, metrics or traces to Grafana Cloud

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -5,6 +5,7 @@ namespacesToMonitor:
 - tempo
 # The name of the cluster where this will be installed
 clusterName: "meta-monitoring"
+httpPort: 3100
 
 # Set to true to write logs, metrics or traces to Grafana Cloud
 cloud:


### PR DESCRIPTION
The log line filtering removed all log lines not matching the pattern, including the agent logs. It should only apply to Loki logs so the namespace is added.