### PR TITLE
Filter out log lines for local Loki as well

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -54,7 +54,7 @@ data:
 
       {{- if not (empty .Values.logs.retain) }}
       stage.match {
-        selector = "{cluster=\"{{- .Values.clusterName -}}\", namespace=\"{{- .Values.lokiNamespace -}}\"} !~ \"{{ join "|" .Values.logs.retain }}\""
+        selector = "{cluster=\"{{- .Values.clusterName -}}\", namespace=~\"{{- .Values.lokiNamespace -}}|{{- .Values.metaMonitoringNamespace -}}\", pod=~\"loki.*\"} !~ \"{{ join "|" .Values.logs.retain }}\""
         action   = "drop"
       }
       {{- end }}

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -5,6 +5,7 @@ namespacesToMonitor:
 - tempo
 # The name of the cluster where this will be installed
 clusterName: "meta-monitoring"
+metaMonitoringNamespace: "mmc"
 lokiNamespace: "loki"
 
 # Set to true to write logs, metrics or traces to Grafana Cloud


### PR DESCRIPTION
When a local Loki is run those logs are also scraped. This applies the same log line filtering to it as to the Loki that is being monitored. This cuts down on the lines stored.