### PR TITLE
Add secrets for credentials and endpoints

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -40,6 +40,16 @@ data:
     // Logs
 
     {{- if or .Values.local.logs.enabled .Values.cloud.logs.enabled }}
+    remote.kubernetes.secret "logs_credentials" {
+      namespace = "{{- .Values.metaMonitoringNamespace -}}"
+      name = "logs"
+    }
+
+    remote.kubernetes.configmap "logs_endpoint" {
+      namespace = "{{- .Values.metaMonitoringNamespace -}}"
+      name = "logs-endpoint"
+    }
+
     loki.source.kubernetes "pods" {
       clustering {
         enabled = true
@@ -75,6 +85,16 @@ data:
     // Metrics
 
     {{- if or .Values.local.metrics.enabled .Values.cloud.metrics.enabled }}
+    remote.kubernetes.secret "metrics_credentials" {
+      namespace = "{{- .Values.metaMonitoringNamespace -}}"
+      name = "metrics"
+    }
+
+    remote.kubernetes.configmap "metrics_endpoint" {
+      namespace = "{{- .Values.metaMonitoringNamespace -}}"
+      name = "metrics-endpoint"
+    }
+
     prometheus.scrape "pods" {
       clustering {
         enabled = true
@@ -210,6 +230,16 @@ data:
     // Traces
 
     {{- if or .Values.local.traces.enabled .Values.cloud.traces.enabled }}
+    remote.kubernetes.secret "traces_credentials" {
+      namespace = "{{- .Values.metaMonitoringNamespace -}}"
+      name = "traces"
+    }
+
+    remote.kubernetes.configmap "traces_endpoint" {
+      namespace = "{{- .Values.metaMonitoringNamespace -}}"
+      name = "traces-endpoint"
+    }
+
     // Shamelessly copied from https://github.com/grafana/intro-to-mlt/blob/main/agent/config.river
     otelcol.receiver.otlp "otlp_receiver" {
       // We don't technically need this, but it shows how to change listen address and incoming port.
@@ -278,11 +308,10 @@ data:
     {{- if .Values.cloud.logs.enabled }}
     loki.write "cloud" {
       endpoint {
-        url = "{{- .Values.cloud.logs.endpoint -}}/loki/api/v1/push"
-
+        url = remote.kubernetes.configmap.logs_endpoint.data["endpoint"]
         basic_auth {
-          username = "{{- .Values.cloud.logs.username -}}"
-          password = "{{- .Values.cloud.logs.password -}}"
+          username = nonsensitive(remote.kubernetes.secret.logs_credentials.data["username"])
+          password = remote.kubernetes.secret.logs_credentials.data["password"]
         }
       }
     }
@@ -291,11 +320,10 @@ data:
     {{- if .Values.cloud.metrics.enabled }}
     prometheus.remote_write "cloud" {
       endpoint {
-        url = "{{- .Values.cloud.metrics.endpoint -}}/api/prom/push"
-
+        url = remote.kubernetes.configmap.metrics_endpoint.data["endpoint"]
         basic_auth {
-          username = "{{- .Values.cloud.metrics.username -}}"
-          password = "{{- .Values.cloud.metrics.password -}}"
+          username = nonsensitive(remote.kubernetes.secret.metrics_credentials.data["username"])
+          password = remote.kubernetes.secret.metrics_credentials.data["password"]
         }
       }
     }
@@ -304,13 +332,13 @@ data:
     {{- if .Values.cloud.traces.enabled }}
     otelcol.exporter.otlp "cloud" {
         client {
-            endpoint = "{{- .Values.cloud.traces.endpoint -}}"
+            endpoint = remote.kubernetes.configmap.traces_endpoint.data["endpoint"]
             auth = otelcol.auth.basic.creds.handler
         }
     }
 
     otelcol.auth.basic "creds" {
-      username = "{{- .Values.cloud.traces.username -}}"
-      password = "{{- .Values.cloud.traces.password -}}"
+      username = nonsensitive(remote.kubernetes.secret.traces_credentials.data["username"])
+      password = remote.kubernetes.secret.traces_credentials.data["password"]
     }
     {{- end }}

--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -45,11 +45,6 @@ data:
       name = "logs"
     }
 
-    remote.kubernetes.configmap "logs_endpoint" {
-      namespace = "{{- .Values.metaMonitoringNamespace -}}"
-      name = "logs-endpoint"
-    }
-
     loki.source.kubernetes "pods" {
       clustering {
         enabled = true
@@ -88,11 +83,6 @@ data:
     remote.kubernetes.secret "metrics_credentials" {
       namespace = "{{- .Values.metaMonitoringNamespace -}}"
       name = "metrics"
-    }
-
-    remote.kubernetes.configmap "metrics_endpoint" {
-      namespace = "{{- .Values.metaMonitoringNamespace -}}"
-      name = "metrics-endpoint"
     }
 
     prometheus.scrape "pods" {
@@ -235,11 +225,6 @@ data:
       name = "traces"
     }
 
-    remote.kubernetes.configmap "traces_endpoint" {
-      namespace = "{{- .Values.metaMonitoringNamespace -}}"
-      name = "traces-endpoint"
-    }
-
     // Shamelessly copied from https://github.com/grafana/intro-to-mlt/blob/main/agent/config.river
     otelcol.receiver.otlp "otlp_receiver" {
       // We don't technically need this, but it shows how to change listen address and incoming port.
@@ -308,7 +293,7 @@ data:
     {{- if .Values.cloud.logs.enabled }}
     loki.write "cloud" {
       endpoint {
-        url = remote.kubernetes.configmap.logs_endpoint.data["endpoint"]
+        url = nonsensitive(remote.kubernetes.secret.logs_credentials.data["endpoint"])
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.logs_credentials.data["username"])
           password = remote.kubernetes.secret.logs_credentials.data["password"]
@@ -320,7 +305,7 @@ data:
     {{- if .Values.cloud.metrics.enabled }}
     prometheus.remote_write "cloud" {
       endpoint {
-        url = remote.kubernetes.configmap.metrics_endpoint.data["endpoint"]
+        url = nonsensitive(remote.kubernetes.secret.metrics_credentials.data["endpoint"])
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_credentials.data["username"])
           password = remote.kubernetes.secret.metrics_credentials.data["password"]
@@ -332,7 +317,7 @@ data:
     {{- if .Values.cloud.traces.enabled }}
     otelcol.exporter.otlp "cloud" {
         client {
-            endpoint = remote.kubernetes.configmap.traces_endpoint.data["endpoint"]
+            endpoint = nonsensitive(remote.kubernetes.secret.traces_credentials.data["endpoint"])
             auth = otelcol.auth.basic.creds.handler
         }
     }

--- a/charts/meta-monitoring/templates/validate.yaml
+++ b/charts/meta-monitoring/templates/validate.yaml
@@ -3,20 +3,20 @@
 {{- end -}}
 
 {{- if eq .Values.cloud.logs.enabled true -}}
-  {{- if or (empty .Values.cloud.logs.endpoint) (or (empty .Values.cloud.logs.username) (empty .Values.cloud.logs.password)) -}}
-    {{- fail "if cloud.logs is enabled then the endpoint, username and password have to be filled in" -}}
+  {{- if or (empty .Values.cloud.logs.secret) (empty .Values.cloud.logs.endpointConfigmap) -}}
+    {{- fail "if cloud.logs is enabled then the secret and endpoint config map have to be filled in" -}}
   {{- end -}}
 {{- end -}}
 
 {{- if eq .Values.cloud.metrics.enabled true -}}
-  {{- if or (empty .Values.cloud.metrics.endpoint) (or (empty .Values.cloud.metrics.username) (empty .Values.cloud.metrics.password)) -}}
-    {{- fail "if cloud.metrics is enabled then the endpoint, username and password have to be filled in" -}}
+  {{- if or (empty .Values.cloud.metrics.secret) (empty .Values.cloud.logs.endpointConfigmap) -}}
+    {{- fail "if cloud.metrics is enabled then the secret and endpoint config map have to be filled in" -}}
   {{- end -}}
 {{- end -}}
 
 {{- if eq .Values.cloud.traces.enabled true -}}
-  {{- if or (empty .Values.cloud.traces.endpoint) (or (empty .Values.cloud.traces.username) (empty .Values.cloud.traces.password)) -}}
-    {{- fail "if cloud.traces is enabled then the endpoint, username and password have to be filled in" -}}
+  {{- if or (empty .Values.cloud.traces.secret) (empty .Values.cloud.logs.endpointConfigmap) -}}
+    {{- fail "if cloud.traces is enabled then the secret and endpoint config map have to be filled in" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/meta-monitoring/templates/validate.yaml
+++ b/charts/meta-monitoring/templates/validate.yaml
@@ -3,20 +3,20 @@
 {{- end -}}
 
 {{- if eq .Values.cloud.logs.enabled true -}}
-  {{- if or (empty .Values.cloud.logs.secret) (empty .Values.cloud.logs.endpointConfigmap) -}}
-    {{- fail "if cloud.logs is enabled then the secret and endpoint config map have to be filled in" -}}
+  {{- if empty .Values.cloud.logs.secret -}}
+    {{- fail "if cloud.logs is enabled then the secret has to be filled in" -}}
   {{- end -}}
 {{- end -}}
 
 {{- if eq .Values.cloud.metrics.enabled true -}}
-  {{- if or (empty .Values.cloud.metrics.secret) (empty .Values.cloud.logs.endpointConfigmap) -}}
-    {{- fail "if cloud.metrics is enabled then the secret and endpoint config map have to be filled in" -}}
+  {{- if empty .Values.cloud.metrics.secret -}}
+    {{- fail "if cloud.metrics is enabled then the secret has to be filled in" -}}
   {{- end -}}
 {{- end -}}
 
 {{- if eq .Values.cloud.traces.enabled true -}}
-  {{- if or (empty .Values.cloud.traces.secret) (empty .Values.cloud.logs.endpointConfigmap) -}}
-    {{- fail "if cloud.traces is enabled then the secret and endpoint config map have to be filled in" -}}
+  {{- if empty .Values.cloud.traces.secret -}}
+    {{- fail "if cloud.traces is enabled then the secret has to be filled in" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -5,7 +5,7 @@ namespacesToMonitor:
 - tempo
 # The name of the cluster where this will be installed
 clusterName: "meta-monitoring"
-metaMonitoringNamespace: "mmc"
+metaMonitoringNamespace: "meta"
 lokiNamespace: "loki"
 
 # Set to true to write logs, metrics or traces to Grafana Cloud

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -12,19 +12,16 @@ lokiNamespace: "loki"
 cloud:
   logs:
     enabled: true
-    endpoint: to_be_changed
-    username: to_be_changed
-    password: to_be_changed
+    secret: ""
+    endpointConfigmap: ""
   metrics:
     enabled: true
-    endpoint: to_be_changed
-    username: to_be_changed
-    password: to_be_changed
+    secret: ""
+    endpointConfigmap: ""
   traces:
     enabled: true
-    endpoint: to_be_changed
-    username: to_be_changed
-    password: to_be_changed
+    secret: ""
+    endpointConfigmap: ""
 
 # Set to true for a local version of logs, metrics or traces
 local:

--- a/charts/meta-monitoring/values.yaml
+++ b/charts/meta-monitoring/values.yaml
@@ -13,15 +13,12 @@ cloud:
   logs:
     enabled: true
     secret: ""
-    endpointConfigmap: ""
   metrics:
     enabled: true
     secret: ""
-    endpointConfigmap: ""
   traces:
     enabled: true
     secret: ""
-    endpointConfigmap: ""
 
 # Set to true for a local version of logs, metrics or traces
 local:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,32 +6,26 @@
    kubectl create namespace meta
    ```
 
-1. Create secrets with credentials and a configmap with the endpoint (as needed) when sending logs, metrics or traces to Grafana Cloud.
+1. Create secrets with credentials and the endpoint when sending logs, metrics or traces to Grafana Cloud.
 
    ```
-   kubectl create configmap logs-endpoint -n meta \
-    --from-literal=endpoint='https://logs-prod-us-central1.grafana.net/loki/api/v1/push'
-
    kubectl create secret generic logs -n meta \
     --from-literal=username=<logs username> \
     --from-literal=password=<logs password>
-
-   kubectl create configmap metrics-endpoint -n meta \
-    --from-literal=endpoint='https://prometheus-us-central1.grafana.net/api/prom/push'
+    --from-literal=endpoint='https://logs-prod-us-central1.grafana.net/loki/api/v1/push'
 
    kubectl create secret generic metrics -n meta \
     --from-literal=username=<metrics username> \
     --from-literal=password=<metrics password>
-
-   kubectl create configmap traces-endpoint -n meta \
-    --from-literal=endpoint='https://tempo-us-central1.grafana.net/tempo'
+    --from-literal=endpoint='https://prometheus-us-central1.grafana.net/api/prom/push'
 
    kubectl create secret generic traces -n meta \
     --from-literal=username=<traces username> \
     --from-literal=password=<traces password>
+    --from-literal=endpoint='https://tempo-us-central1.grafana.net/tempo'
    ```
 
-1. Create a values.yaml file based on the [default one](../charts/meta-monitoring/values.yaml). Fill in the names of the secrets and configmaps created above as needed.
+1. Create a values.yaml file based on the [default one](../charts/meta-monitoring/values.yaml). Fill in the names of the secrets created above as needed.
 
 1. Install this helm chart
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,32 @@
    kubectl create namespace meta
    ```
 
-1. Create a values.yaml file based on the [default one](../charts/meta-monitoring/values.yaml).
+1. Create secrets with credentials and a configmap with the endpoint (as needed) when sending logs, metrics or traces to Grafana Cloud.
+
+   ```
+   kubectl create configmap logs-endpoint -n meta \
+    --from-literal=endpoint='https://logs-prod-us-central1.grafana.net/loki/api/v1/push'
+
+   kubectl create secret generic logs -n meta \
+    --from-literal=username=<logs username> \
+    --from-literal=password=<logs password>
+
+   kubectl create configmap metrics-endpoint -n meta \
+    --from-literal=endpoint='https://prometheus-us-central1.grafana.net/api/prom/push'
+
+   kubectl create secret generic metrics -n meta \
+    --from-literal=username=<metrics username> \
+    --from-literal=password=<metrics password>
+
+   kubectl create configmap traces-endpoint -n meta \
+    --from-literal=endpoint='https://tempo-us-central1.grafana.net/tempo'
+
+   kubectl create secret generic traces -n meta \
+    --from-literal=username=<traces username> \
+    --from-literal=password=<traces password>
+   ```
+
+1. Create a values.yaml file based on the [default one](../charts/meta-monitoring/values.yaml). Fill in the names of the secrets and configmaps created above as needed.
 
 1. Install this helm chart
 


### PR DESCRIPTION
The username, password and endpoint are now fetched from a k8s Secret that is referenced in the values.yaml. This avoids having secrets in the values.yaml file.

The docs have been updated. 