### PR TITLE
Do not create ruler for dashboards when Grafana is not enabled

### DIFF
--- a/charts/meta-monitoring/templates/ruler/ruler.yaml
+++ b/charts/meta-monitoring/templates/ruler/ruler.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.local.metrics.enabled }}
-{{- if or (or .Values.dashboards.logs.enabled .Values.dashboards.metrics.enabled) .Values.dashboards.traces.enabled }}
+{{- if .Values.local.grafana.enabled }}
+{{- if and .Values.local.grafana.enabled (or .Values.dashboards.logs.enabled .Values.dashboards.metrics.enabled .Values.dashboards.traces.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Dashboards are not installed if Grafana is not installed. The ruler for the dashboards should not be installed either.