### PR TITLE
Fix local tracing pipeline

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -346,7 +346,7 @@ data:
     {{- if .Values.local.traces.enabled }}
     otelcol.exporter.otlphttp "local" {
         client {
-            endpoint = "http://{{- .Release.Name -}}-tempo-distributor.svc:4318"
+            endpoint = "http://{{- .Release.Name -}}-tempo-distributor.{{- .Release.Namespace -}}.svc:4318"
         }
     }
     {{- end }}


### PR DESCRIPTION
The otel exporter was missing the namespace in the endpoint for the local mode. This caused spans to be dropped.
This was tested by sending traces to the alloy otlp receiver and checking they arrived in Tempo.