### PR TITLE
Fix local write end point

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -330,7 +330,7 @@ data:
     {{- if .Values.local.logs.enabled }}
     loki.write "local" {
       endpoint {
-        url = "http://{{- .Release.Namespace -}}-loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local:80/loki/api/v1/push"
+        url = "http://loki-write.{{- .Release.Namespace -}}.svc.cluster.local:3100/loki/api/v1/push"
       }
     }
     {{- end }}


### PR DESCRIPTION
The local Loki is installed as an SSD without a gateway so the service DNS address can be used.
Tested by manually setting it in a dev environment.