### PR TITLE
Added drop discovery.relabel "only_http_metrics" rule to not scrape the memberlist port

### DIFF
--- a/charts/meta-monitoring/templates/agent/config.yaml
+++ b/charts/meta-monitoring/templates/agent/config.yaml
@@ -124,6 +124,11 @@ data:
         action = "drop"
         regex = "9095"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_port_number"]
+        action = "drop"
+        regex = "7946"
+      }
     }
 
     prometheus.scrape "pods" {


### PR DESCRIPTION
When using this chart to monitor GEL, I noticed all the GEL pods continually emitting logs with this line:
`msg="unknown message type" msgType=G`

Realized it was due to Alloy trying to scrape the metrics endpoint on the memberlist port. 

Testing this additional rule to the `discovery.relabel.only_http_metrics` component, resolved the error logs being emitted.