### PR TITLE
Derive mimir image from chart when metrics enabled and fallback to up…

### DIFF
--- a/charts/meta-monitoring/templates/ruler/ruler.yaml
+++ b/charts/meta-monitoring/templates/ruler/ruler.yaml
@@ -36,7 +36,7 @@ spec:
             - -ruler.ring.prefix=dashboards/
             - -config.expand-env=true
             - -config.file=/etc/mimir/mimir.yaml
-          image: grafana/mimir:2.8.0
+          image: {{ if .Values.local.metrics.enabled }}{{ include "mimir.imageReference" (index .Subcharts "mimir-distributed") }}{{ else }}grafana/mimir:2.12.0{{ end }}
           imagePullPolicy: IfNotPresent
           name: ruler
           ports:


### PR DESCRIPTION
…dated mimir image

I ran into an issue when trying to spawn a new cluster using this chart where some conifguration values in the configmap for /etc/mimir/mimir.yaml were not recognized for the mimir-for-ruler-dashboards deployment. After some digging, it appears that the version of mimir that the 5.3.0 version of the mimir chart that this chart uses is 2.12.0 but the mimir-ruler-for-dashboards deployment in this chart was using 2.8.0 and there was a config compatibility issue. 

I updated the default image version for mimir to 2.12.0 to match and also added logic to pull in the imageReference from the mimir-distributed chart when possible so that it can remain in sync.

Please let me know if there's anything you need changed. If you're not accepting PRs at this time I can also close this one down.